### PR TITLE
refactor: scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,9 @@
 		"@wordpress/prettier-config": "^2.12.0",
 		"@wordpress/scripts": "^26.0.0",
 		"@wordpress/stylelint-config": "^21.12.0",
+		"@wp-blocks/scripts": "workspace:^0.1.0",
 		"@wp-blocks/tsconfig": "workspace:^0.1.0",
-		"@wp-blocks/wp-update": "workspace:^0.1.0",
+		"@wp-blocks/wp-update": "workspace:^0.2.0",
 		"babel-jest": "^29.4.3",
 		"eslint": "^8.34.0",
 		"eslint-import-resolver-typescript": "^3.5.3",
@@ -80,8 +81,5 @@
 		"stylelint": "^14.16.1",
 		"turbo": "^1.8.1",
 		"typescript": "^5.0.2"
-	},
-	"devDependencies": {
-		"@wp-blocks/scripts": "workspace:^0.1.0"
 	}
 }

--- a/packages/scripts/bin/index.js
+++ b/packages/scripts/bin/index.js
@@ -8,6 +8,8 @@ import buildDocs from '../src/run-api-documenter.js';
 import buildTypes from '../src/run-api-extractor.js';
 import buildCompile from '../src/run-tsc.js';
 
+const CI = process.env.CI;
+
 const argv = yargs( process.argv.slice( 2 ) )
 	.command( [ 'build', 'compile' ], 'transpile TypeScript', ( yargs ) => {
 		yargs.options( {
@@ -42,8 +44,17 @@ const argv = yargs( process.argv.slice( 2 ) )
 
 const [ , cmd ] = argv._;
 
-const options = { local: !! argv.l };
-console.log( options );
+/**
+ * The `--local` flag is to indicate the build process is happening on a local
+ * development computer. In CI it should be `false`. Specifically `tsc` and
+ * `api-extractor` are provided different CLI arguments in a local environment.
+ *
+ * TODO This concept might be flawed. Currently if `CI=true` it works as intended,
+ * but overrides the `--local` flag that is in all the scripts, which seems counter
+ * intuitive.
+ */
+const options = { local: CI ? false : !! argv.l };
+
 if ( cmd === 'compile' ) {
 	await buildCompile( options );
 } else if ( cmd === 'docs' ) {

--- a/packages/scripts/src/build-pkg.js
+++ b/packages/scripts/src/build-pkg.js
@@ -1,6 +1,3 @@
-import buildEsm from './copy-esm.js';
-import buildTypes from './run-api-extractor.js';
-import buildCompile from './run-tsc.js';
 import { exec } from './utils/exec.js';
 
 /**
@@ -8,13 +5,13 @@ import { exec } from './utils/exec.js';
  * @param {boolean} options.local - Local development flag.
  */
 export default async function ( options ) {
-	if ( ! options.local ) {
-		await exec( 'pnpm', [ 'run', 'clean:all' ] );
+	if ( options.local ) {
+		await exec( 'pnpm', [ 'clean:all' ] );
 	}
 	try {
-		await buildCompile( options );
-		buildEsm();
-		await buildTypes( options );
+		await exec( 'pnpm', [ 'build:compile' ] );
+		await exec( 'pnpm', [ 'build:esm' ] );
+		await exec( 'pnpm', [ 'build:types' ] );
 	} catch ( code ) {
 		process.exit( code );
 	}

--- a/packages/scripts/src/copy-esm.js
+++ b/packages/scripts/src/copy-esm.js
@@ -6,10 +6,14 @@ import { copy } from './utils/index.js';
 
 /**
  * Copy ESM output of `tsc` to build directory.
+ *
+ * Includes source maps if present.
  */
 export default function () {
 	const fromDir = path.resolve( './lib' );
 	const toDir = path.resolve( './build' );
 
-	copy( fromDir, toDir, ( file ) => path.extname( file ) === '.js' );
+	copy( fromDir, toDir, ( file ) =>
+		/\.js(?:\.map)?$/.test( path.basename( file ) )
+	);
 }

--- a/packages/scripts/src/run-api-documenter.js
+++ b/packages/scripts/src/run-api-documenter.js
@@ -10,7 +10,7 @@ export default async function () {
 	/**
 	 * ApiDocumenter CLI arguments.
 	 */
-	const apiDocumenterArgs = [ 'markdown', '-i', './temp', '-o', './docs' ];
+	const apiDocumenterArgs = [ 'markdown', '-i', 'temp', '-o', 'docs' ];
 
 	console.log( `api-documenter ${ apiDocumenterArgs.join( ' ' ) }` );
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,7 +23,7 @@
 		"npm": ">=6.14.4"
 	},
 	"scripts": {
-		"build:pkg": "wp-blocks build pkg",
+		"build:pkg": "wp-blocks build pkg --local",
 		"build:esm": "wp-blocks build esm",
 		"build:compile": "wp-blocks build compile --local",
 		"build:types": "wp-blocks build types --local",

--- a/packages/wp-update/package.json
+++ b/packages/wp-update/package.json
@@ -53,6 +53,7 @@
 		"yargs": "^17.7.1"
 	},
 	"devDependencies": {
-		"@types/yargs": "^17.0.22"
+		"@types/yargs": "^17.0.22",
+		"@wp-blocks/scripts": "workspace:^0.1.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
       '@wordpress/stylelint-config': ^21.12.0
       '@wp-blocks/scripts': workspace:^0.1.0
       '@wp-blocks/tsconfig': workspace:^0.1.0
-      '@wp-blocks/wp-update': workspace:^0.1.0
+      '@wp-blocks/wp-update': workspace:^0.2.0
       babel-jest: ^29.4.3
       eslint: ^8.34.0
       eslint-import-resolver-typescript: ^3.5.3
@@ -77,6 +77,7 @@ importers:
       '@wordpress/prettier-config': 2.12.0_prettier@2.8.4
       '@wordpress/scripts': 26.0.0_4w3h7madzjlbgvvvqm4eewwmma
       '@wordpress/stylelint-config': 21.12.0_w5gtdy6oq4ictd5o4eu6befejy
+      '@wp-blocks/scripts': link:packages/scripts
       '@wp-blocks/tsconfig': link:packages/tsconfig
       '@wp-blocks/wp-update': link:packages/wp-update
       babel-jest: 29.4.3_@babel+core@7.21.0
@@ -96,8 +97,6 @@ importers:
       stylelint: 14.16.1
       turbo: 1.8.1
       typescript: 5.0.2
-    devDependencies:
-      '@wp-blocks/scripts': link:packages/scripts
 
   examples/counter:
     specifiers: {}
@@ -133,6 +132,7 @@ importers:
   packages/wp-update:
     specifiers:
       '@types/yargs': ^17.0.22
+      '@wp-blocks/scripts': workspace:^0.1.0
       node-fetch: ^3.3.1
       picocolors: ^1.0.0
       prettier: ^2.8.4
@@ -144,6 +144,7 @@ importers:
       yargs: 17.7.1
     devDependencies:
       '@types/yargs': 17.0.22
+      '@wp-blocks/scripts': link:../scripts
 
 packages:
 


### PR DESCRIPTION
There were some issues with how `wp-blocks build pkg` handled calling all the scripts, switched to calling the build commands in a sequence of exec calls to `pnpm`.