### PR TITLE
ci: add os matrix

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: "16"
+        node-version: ${{ matrix.node_version }}
 
     - uses: pnpm/action-setup@v2
       name: Install pnpm

--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node_version }}
+        node-version: 16.x
 
     - uses: pnpm/action-setup@v2
       name: Install pnpm

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -12,12 +12,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -14,7 +14,6 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,6 +10,8 @@ env:
   CI: true
 
 jobs:
+  runs-on: ${{ matrix.os }}
+
   build:
     strategy:
       matrix:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -11,11 +11,10 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -13,7 +13,6 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,14 +10,14 @@ env:
   CI: true
 
 jobs:
-  runs-on: ${{ matrix.os }}
-
   build:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
I build this monorepo while working on a Mac, some cross platform compatibility issues became obvious once it was run on Windows. Running the CI builds on multiple OS could help catch issues like that in the future.